### PR TITLE
Add celebratory canvas overlay for top leaderboard run

### DIFF
--- a/pub/v2.html
+++ b/pub/v2.html
@@ -303,7 +303,7 @@
     }
 
     // ===== Celebration overlay =====
-    const celebration = { running:false, canvas:null, ctx:null, raf:0, ducks:[], cats:[], particles:[] };
+    const celebration = { running:false, canvas:null, ctx:null, raf:0, ducks:[], cats:[], particles:[], flashes:{left:0,right:0} };
     function resizeCelebration(){
       if (!celebration.canvas) return;
       const dpr = window.devicePixelRatio || 1;
@@ -316,24 +316,67 @@
     function spawnDuck(){
       const w = celebration.canvas.width / (window.devicePixelRatio||1);
       const h = celebration.canvas.height / (window.devicePixelRatio||1);
-      const fromLeft = Math.random()<0.5;
-      const x = fromLeft ? 0 : w;
-      const y = h-20;
-      const angle = fromLeft ? (Math.random()*0.5+0.2) : Math.PI - (Math.random()*0.5+0.2);
-      const speed = 4 + Math.random()*2;
-      celebration.ducks.push({x,y,vx:Math.cos(angle)*speed,vy:-Math.sin(angle)*speed});
+      const fromLeft = Math.random() < 0.5;
+      const x = fromLeft ? 60 : w-60;
+      const y = h-40;
+      const ang = fromLeft ? (Math.random()*0.3 + 0.5) : Math.PI - (Math.random()*0.3 + 0.5);
+      const sp = 5 + Math.random()*2;
+      celebration.ducks.push({x,y,vx:Math.cos(ang)*sp,vy:-Math.sin(ang)*sp});
+      celebration.flashes[fromLeft? 'left' : 'right'] = 5;
     }
     function spawnCat(){
       const w = celebration.canvas.width / (window.devicePixelRatio||1);
       const h = celebration.canvas.height / (window.devicePixelRatio||1);
-      celebration.cats.push({x:w/2+(Math.random()-0.5)*100,y:h-20,vy:-(6+Math.random()*2)});
+      celebration.cats.push({x:w/2+(Math.random()-0.5)*100,y:h-40,vy:-(6+Math.random()*2)});
     }
     function makeFireworks(x,y){
-      for(let i=0;i<20;i++){
+      for(let i=0;i<32;i++){
         const ang=Math.random()*Math.PI*2;
-        const sp=2+Math.random()*2;
+        const sp=2+Math.random()*2.5;
         celebration.particles.push({x,y,vx:Math.cos(ang)*sp,vy:Math.sin(ang)*sp,life:60,color:`hsl(${Math.random()*360},80%,60%)`});
       }
+    }
+    function drawCannon(ctx,x,y,dir,flash){
+      ctx.save();
+      ctx.translate(x,y);
+      ctx.rotate(dir);
+      ctx.fillStyle='#555';
+      ctx.fillRect(-20,-10,40,20); // barrel
+      ctx.beginPath();
+      ctx.arc(-20,0,10,Math.PI/2,Math.PI*3/2);
+      ctx.fill();
+      if (flash>0){
+        ctx.fillStyle='orange';
+        ctx.beginPath();
+        ctx.arc(22,0,flash*2,0,Math.PI*2);
+        ctx.fill();
+      }
+      ctx.restore();
+    }
+    function drawDuck(ctx,d){
+      const ang=Math.atan2(d.vy,d.vx);
+      ctx.save();
+      ctx.translate(d.x,d.y);
+      ctx.rotate(ang);
+      ctx.fillStyle='gold';
+      ctx.beginPath(); ctx.ellipse(0,0,10,7,0,0,Math.PI*2); ctx.fill(); // body
+      ctx.beginPath(); ctx.arc(8,-5,5,0,Math.PI*2); ctx.fill(); // head
+      ctx.fillStyle='orange';
+      ctx.beginPath(); ctx.moveTo(13,-5); ctx.lineTo(17,-3); ctx.lineTo(13,-1); ctx.closePath(); ctx.fill(); // beak
+      ctx.fillStyle='goldenrod';
+      ctx.beginPath(); ctx.moveTo(-3,-2); ctx.lineTo(-15,-8); ctx.lineTo(-5,0); ctx.closePath(); ctx.fill(); // wing
+      ctx.restore();
+    }
+    function drawCat(ctx,c){
+      ctx.save();
+      ctx.translate(c.x,c.y);
+      ctx.fillStyle='#555';
+      ctx.beginPath(); ctx.arc(0,0,8,0,Math.PI*2); ctx.fill(); // head
+      ctx.beginPath(); ctx.moveTo(-5,-3); ctx.lineTo(-9,-8); ctx.lineTo(-1,-4); ctx.closePath(); ctx.fill(); // left ear
+      ctx.beginPath(); ctx.moveTo(5,-3); ctx.lineTo(1,-8); ctx.lineTo(9,-4); ctx.closePath(); ctx.fill(); // right ear
+      ctx.fillStyle='#fff';
+      ctx.beginPath(); ctx.arc(-3,0,1.5,0,Math.PI*2); ctx.arc(3,0,1.5,0,Math.PI*2); ctx.fill(); // eyes
+      ctx.restore();
     }
     function animateCelebration(){
       if (!celebration.running) return;
@@ -341,9 +384,10 @@
       const w = celebration.canvas.width / (window.devicePixelRatio||1);
       const h = celebration.canvas.height / (window.devicePixelRatio||1);
       ctx.clearRect(0,0,w,h);
-      ctx.fillStyle='#444';
-      ctx.fillRect(10,h-20,40,10);
-      ctx.fillRect(w-50,h-20,40,10);
+      drawCannon(ctx,60,h-40,Math.PI/4,celebration.flashes.left);
+      drawCannon(ctx,w-60,h-40,3*Math.PI/4,celebration.flashes.right);
+      celebration.flashes.left = Math.max(celebration.flashes.left-1,0);
+      celebration.flashes.right = Math.max(celebration.flashes.right-1,0);
       if (Math.random()<0.05) spawnDuck();
       if (Math.random()<0.02) spawnCat();
       celebration.ducks.forEach(d=>{
@@ -351,16 +395,15 @@
       });
       celebration.ducks = celebration.ducks.filter(d=>d.y<h);
       celebration.cats.forEach(c=>{
+        celebration.particles.push({x:c.x,y:c.y+10,vx:(Math.random()-0.5)*0.3,vy:1+Math.random()*0.5,life:20,color:'rgba(255,165,0,0.5)'});
         c.y+=c.vy; c.vy+=0.1; if (c.vy>0){ makeFireworks(c.x,c.y); c.dead=true; }
       });
       celebration.cats = celebration.cats.filter(c=>!c.dead && c.y<h);
       celebration.particles.forEach(p=>{
         p.x+=p.vx; p.y+=p.vy; p.vy+=0.02; p.life--;});
       celebration.particles = celebration.particles.filter(p=>p.life>0);
-      ctx.fillStyle='yellow';
-      celebration.ducks.forEach(d=>{ ctx.beginPath(); ctx.arc(d.x,d.y,8,0,Math.PI*2); ctx.fill(); });
-      ctx.fillStyle='orange';
-      celebration.cats.forEach(c=>{ ctx.fillRect(c.x-6,c.y-6,12,12); });
+      celebration.ducks.forEach(d=>{ drawDuck(ctx,d); });
+      celebration.cats.forEach(c=>{ drawCat(ctx,c); });
       celebration.particles.forEach(p=>{ ctx.fillStyle=p.color; ctx.beginPath(); ctx.arc(p.x,p.y,3,0,Math.PI*2); ctx.fill(); });
       celebration.raf = requestAnimationFrame(animateCelebration);
     }
@@ -370,7 +413,7 @@
       if (!celebration.canvas) return;
       celebration.ctx = celebration.canvas.getContext('2d');
       celebration.running = true;
-      celebration.ducks=[]; celebration.cats=[]; celebration.particles=[];
+      celebration.ducks=[]; celebration.cats=[]; celebration.particles=[]; celebration.flashes={left:0,right:0};
       resizeCelebration();
       window.addEventListener('resize', resizeCelebration);
       celebration.raf = requestAnimationFrame(animateCelebration);

--- a/pub/v2.html
+++ b/pub/v2.html
@@ -79,6 +79,7 @@
     .mt-3{margin-top:12px}
     .mt-4{margin-top:18px}
     .mt-6{margin-top:28px}
+    #celebration-canvas{position:fixed;inset:0;width:100%;height:100%;pointer-events:none;z-index:9999}
     .hidden{display:none !important}
   </style>
 </head>
@@ -207,6 +208,7 @@
       </div>
     </section>
   </div>
+  <canvas id="celebration-canvas"></canvas>
 
   <script type="module">
     // ===== Constants =====
@@ -297,6 +299,101 @@
           <td class="mono">${r.correctCount}/${GAME_LEN}</td>
           <td class="mono">${fmt(r.avgMsPerFlag)}</td>`;
         tbody.appendChild(tr);
+      });
+    }
+
+    // ===== Celebration overlay =====
+    const celebration = { running:false, canvas:null, ctx:null, raf:0, ducks:[], cats:[], particles:[] };
+    function resizeCelebration(){
+      if (!celebration.canvas) return;
+      const dpr = window.devicePixelRatio || 1;
+      celebration.canvas.width = window.innerWidth * dpr;
+      celebration.canvas.height = window.innerHeight * dpr;
+      celebration.canvas.style.width = '100%';
+      celebration.canvas.style.height = '100%';
+      celebration.ctx.setTransform(dpr,0,0,dpr,0,0);
+    }
+    function spawnDuck(){
+      const w = celebration.canvas.width / (window.devicePixelRatio||1);
+      const h = celebration.canvas.height / (window.devicePixelRatio||1);
+      const fromLeft = Math.random()<0.5;
+      const x = fromLeft ? 0 : w;
+      const y = h-20;
+      const angle = fromLeft ? (Math.random()*0.5+0.2) : Math.PI - (Math.random()*0.5+0.2);
+      const speed = 4 + Math.random()*2;
+      celebration.ducks.push({x,y,vx:Math.cos(angle)*speed,vy:-Math.sin(angle)*speed});
+    }
+    function spawnCat(){
+      const w = celebration.canvas.width / (window.devicePixelRatio||1);
+      const h = celebration.canvas.height / (window.devicePixelRatio||1);
+      celebration.cats.push({x:w/2+(Math.random()-0.5)*100,y:h-20,vy:-(6+Math.random()*2)});
+    }
+    function makeFireworks(x,y){
+      for(let i=0;i<20;i++){
+        const ang=Math.random()*Math.PI*2;
+        const sp=2+Math.random()*2;
+        celebration.particles.push({x,y,vx:Math.cos(ang)*sp,vy:Math.sin(ang)*sp,life:60,color:`hsl(${Math.random()*360},80%,60%)`});
+      }
+    }
+    function animateCelebration(){
+      if (!celebration.running) return;
+      const ctx = celebration.ctx;
+      const w = celebration.canvas.width / (window.devicePixelRatio||1);
+      const h = celebration.canvas.height / (window.devicePixelRatio||1);
+      ctx.clearRect(0,0,w,h);
+      ctx.fillStyle='#444';
+      ctx.fillRect(10,h-20,40,10);
+      ctx.fillRect(w-50,h-20,40,10);
+      if (Math.random()<0.05) spawnDuck();
+      if (Math.random()<0.02) spawnCat();
+      celebration.ducks.forEach(d=>{
+        d.x+=d.vx; d.y+=d.vy; d.vy+=0.05;
+      });
+      celebration.ducks = celebration.ducks.filter(d=>d.y<h);
+      celebration.cats.forEach(c=>{
+        c.y+=c.vy; c.vy+=0.1; if (c.vy>0){ makeFireworks(c.x,c.y); c.dead=true; }
+      });
+      celebration.cats = celebration.cats.filter(c=>!c.dead && c.y<h);
+      celebration.particles.forEach(p=>{
+        p.x+=p.vx; p.y+=p.vy; p.vy+=0.02; p.life--;});
+      celebration.particles = celebration.particles.filter(p=>p.life>0);
+      ctx.fillStyle='yellow';
+      celebration.ducks.forEach(d=>{ ctx.beginPath(); ctx.arc(d.x,d.y,8,0,Math.PI*2); ctx.fill(); });
+      ctx.fillStyle='orange';
+      celebration.cats.forEach(c=>{ ctx.fillRect(c.x-6,c.y-6,12,12); });
+      celebration.particles.forEach(p=>{ ctx.fillStyle=p.color; ctx.beginPath(); ctx.arc(p.x,p.y,3,0,Math.PI*2); ctx.fill(); });
+      celebration.raf = requestAnimationFrame(animateCelebration);
+    }
+    function startCelebration(){
+      if (celebration.running) return;
+      celebration.canvas = qs('#celebration-canvas');
+      if (!celebration.canvas) return;
+      celebration.ctx = celebration.canvas.getContext('2d');
+      celebration.running = true;
+      celebration.ducks=[]; celebration.cats=[]; celebration.particles=[];
+      resizeCelebration();
+      window.addEventListener('resize', resizeCelebration);
+      celebration.raf = requestAnimationFrame(animateCelebration);
+    }
+    function stopCelebration(){
+      if (!celebration.running) return;
+      celebration.running = false;
+      cancelAnimationFrame(celebration.raf);
+      window.removeEventListener('resize', resizeCelebration);
+      celebration.ctx && celebration.ctx.clearRect(0,0,celebration.canvas.width,celebration.canvas.height);
+    }
+    function bindCelebrationKeys(){
+      const handler = e => {
+        if (e.key === 'c' || e.key === 'C'){
+          celebration.running ? stopCelebration() : startCelebration();
+        } else if (e.key === 'Escape'){
+          stopCelebration();
+        }
+      };
+      window.addEventListener('keydown', handler);
+      window.addEventListener('beforeunload', ()=>{
+        window.removeEventListener('keydown', handler);
+        stopCelebration();
       });
     }
 
@@ -459,6 +556,8 @@
         lastFlagMs: lastFlag.elapsedMs
       };
       insertLB(row);
+      const latest = getLB();
+      if (latest[0]?.runId === row.runId) startCelebration();
       // Render results
       qs('#res-elapsed').textContent = fmt(state.totals.elapsedMs);
       qs('#res-pen').textContent = fmt(state.totals.penaltyMs);
@@ -536,6 +635,7 @@
     document.addEventListener('DOMContentLoaded', () => {
       bindUI();
       bindButtons();
+      bindCelebrationKeys();
       renderLB('#leaderboard');
       const optBlur = qs('#opt-blur');
       if (optBlur) {


### PR DESCRIPTION
## Summary
- detect high-score completion and start celebration
- add full-screen celebration canvas with duck/cat fireworks animation
- enable keyboard shortcuts to toggle celebration and handle cleanup

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node - <<'NODE'\nconst fs=require('fs'), vm=require('vm');\nconst html=fs.readFileSync('pub/v2.html','utf8');\nconst script=html.match(/<script type=\"module\">([\\s\\S]*?)<\\/script>/)[1];\nnew vm.Script(script);\nconsole.log('syntax ok');\nNODE`

------
https://chatgpt.com/codex/tasks/task_e_689ef0adaee88321ac3a061190890900